### PR TITLE
Fix README start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ cd FitBuddy
    
 npm install
 
-3. Start the development server:
+3. Start the development server using the `dev` script:
 
-npm start
+npm run dev
 
 
 The app will be running at `http://localhost:3000/`.


### PR DESCRIPTION
## Summary
- correct the development server command in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f4bfb8f60832285b8c2e1d9fec6c9