### PR TITLE
Fix SignUp button handler

### DIFF
--- a/src/components/SignUp/SignUp.jsx
+++ b/src/components/SignUp/SignUp.jsx
@@ -27,7 +27,7 @@ export default function Signup() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
 
-  function handleSignUp(e) {
+  function handleSignUp() {
     createUserWithEmailAndPassword(auth, email, password)
       .then((userCredentials) => {
         const user = userCredentials.user;
@@ -116,7 +116,7 @@ export default function Signup() {
                   _hover={{
                     bg: "teal.500",
                   }}
-                  onClick={handleSignUp()}
+                  onClick={handleSignUp}
                 >
                   Sign up
                 </Button>


### PR DESCRIPTION
## Summary
- ensure `handleSignUp` is only run on click

## Testing
- `npm run lint` *(fails: couldn't find eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_683f4bf6e6ec8322881ff052fff9193c