### PR TITLE
Add SignUp test with RTL and jest

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', {targets: {node: 'current'}}],
+    ['@babel/preset-react', {runtime: 'automatic'}]
+  ],
+};

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,10 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.[jt]sx?$': 'babel-jest',
+  },
+  moduleNameMapper: {
+    '\\.(css|scss|sass)$': 'identity-obj-proxy'
+  },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+};

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "@chakra-ui/icons": "^2.1.0",
@@ -44,6 +45,14 @@
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.3",
-    "vite": "^4.4.5"
+    "vite": "^4.4.5",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/user-event": "^14.4.3",
+    "jest": "^29.6.0",
+    "babel-jest": "^29.6.0",
+    "@babel/preset-env": "^7.22.5",
+    "@babel/preset-react": "^7.22.5",
+    "identity-obj-proxy": "^3.0.0"
   }
 }

--- a/src/__tests__/SignUp.test.jsx
+++ b/src/__tests__/SignUp.test.jsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Signup from '../components/SignUp/SignUp';
+import * as firebaseAuth from 'firebase/auth';
+
+describe('SignUp', () => {
+  it('calls createUserWithEmailAndPassword on sign up', async () => {
+    const mockCreate = jest.spyOn(firebaseAuth, 'createUserWithEmailAndPassword').mockResolvedValue({ user: { email: 'test@example.com' } });
+    render(<Signup />);
+
+    const emailInput = screen.getByLabelText(/email address/i);
+    const passwordInput = screen.getByLabelText(/password/i);
+    await userEvent.type(emailInput, 'test@example.com');
+    await userEvent.type(passwordInput, 'password');
+
+    const button = screen.getByRole('button', { name: /sign up/i });
+    await userEvent.click(button);
+
+    expect(mockCreate).toHaveBeenCalled();
+    mockCreate.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest test for SignUp component
- configure Jest with Babel and jsdom
- install React Testing Library and Jest dependencies
- expose npm test script

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4d6abfb4832296864cfb042efe82