### PR TITLE
Improve homepage appearance

### DIFF
--- a/src/components/GetStarted/GetStarted.jsx
+++ b/src/components/GetStarted/GetStarted.jsx
@@ -1,6 +1,6 @@
 import logo from "../../assets/logo/logo.png";
 import "../../components/GetStarted/GetStarted.scss";
-import { Button, Stack } from "@chakra-ui/react";
+import { Button } from "@chakra-ui/react";
 import { Link } from "react-router-dom";
 
 export default function GetStarted() {

--- a/src/components/GetStarted/GetStarted.scss
+++ b/src/components/GetStarted/GetStarted.scss
@@ -9,12 +9,16 @@
 /* GetStarted.scss */
 
 .container {
-  height: 100vh;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  align-items: center;
+  padding: 2rem;
+  background: linear-gradient(135deg, #f0fff4, #c6f6d5);
   &__img {
     width: 200px;
+    margin-top: 2rem;
   }
 }
 
@@ -36,4 +40,16 @@
   display: flex;
   flex-direction: column;
   align-items: center; /* Center buttons horizontally */
+}
+
+h1 {
+  margin-top: 1rem;
+  font-size: 2.5rem;
+  color: $button-background;
+}
+
+p {
+  margin-top: 0.5rem;
+  font-size: 1.2rem;
+  color: #555;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,6 @@
 
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  background-color: #f9fafb;
+}


### PR DESCRIPTION
## Summary
- clean up unused import in `GetStarted`
- style GetStarted with gradient, centered layout, and larger headings
- add base body styles

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4ffae84883228454ea70d9172146